### PR TITLE
remove service timeout

### DIFF
--- a/include/webfuse/adapter/server.h
+++ b/include/webfuse/adapter/server.h
@@ -46,16 +46,12 @@ extern WF_API void wf_server_dispose(
 /// This function must be invoked in a loop while the server is running. It
 /// makes the server wait for the next event and processes it.
 ///
-/// \note timeout_ms is no longer used
-///
 /// \param server pointer to server
-/// \param timeout_ms unused; set to 0; used for backward compatibility
 ///
 /// \see wf_server_interrupt
 //------------------------------------------------------------------------------
 extern WF_API void wf_server_service(
-    struct wf_server * server,
-    int timeout_ms);
+    struct wf_server * server);
 
 //------------------------------------------------------------------------------
 /// \brief Interrupts wf_server_service

--- a/include/webfuse/provider/client.h
+++ b/include/webfuse/provider/client.h
@@ -78,16 +78,12 @@ extern WFP_API void wfp_client_dispose(
 /// This function must be invoked in a loop while the client is running. It
 /// makes the server wait for the next event and processes it.
 ///
-/// \note timeout is ignored
-///
 /// \param client pointer to client
-/// \param timeout_ms unused; set to 0; for backward compatibilty
 ///
 /// \see wfp_client_interrupt
 //------------------------------------------------------------------------------
 extern WFP_API void wfp_client_service(
-    struct wfp_client * client,
-    int timeout_ms);
+    struct wfp_client * client);
 
 //------------------------------------------------------------------------------
 /// \brief interrupt wfp_client_service

--- a/lib/webfuse/adapter/api.c
+++ b/lib/webfuse/adapter/api.c
@@ -23,8 +23,7 @@ void wf_server_dispose(
 }
 
 void wf_server_service(
-    struct wf_server * server,
-    int WF_UNUSED_PARAM(imeout_ms))
+    struct wf_server * server)
 {
     wf_impl_server_service(server);
 }

--- a/lib/webfuse/provider/api.c
+++ b/lib/webfuse/provider/api.c
@@ -231,8 +231,7 @@ void wfp_client_dispose(
 }
 
 void wfp_client_service(
-    struct wfp_client * client,
-    int WF_UNUSED_PARAM(timeout_ms))
+    struct wfp_client * client)
 {
     wfp_impl_client_service(client);
 }

--- a/test/webfuse/tests/integration/provider.cc
+++ b/test/webfuse/tests/integration/provider.cc
@@ -30,7 +30,7 @@ public:
         wfp_client_connect(client, url);
         while (!wfp_impl_client_is_connected(client))
         {
-            wfp_client_service(client, 100);
+            wfp_client_service(client);
         }
        
         thread = std::thread(Run, this);
@@ -65,7 +65,7 @@ private:
     {
         while (!context->IsShutdownRequested())
         {
-            wfp_client_service(context->client, 100);
+            wfp_client_service(context->client);
         }
     }
 

--- a/test/webfuse/tests/integration/server.cc
+++ b/test/webfuse/tests/integration/server.cc
@@ -70,7 +70,7 @@ public:
 
         while (!wf_impl_server_is_operational(server))
         {
-            wf_server_service(server, 100);
+            wf_server_service(server);
         }
 
         thread = std::thread(Run, this);
@@ -104,7 +104,7 @@ private:
     {
         while (!context->IsShutdownRequested())
         {
-            wf_server_service(context->server, 100);
+            wf_server_service(context->server);
         }
     }
 


### PR DESCRIPTION
Both, `wf_server_service `and `wfp_client_service `have a second argument `timeout_ms`, which is not used anymore. Therefore, it should be removed.

**Note, that this is an API breaking change.**