### PR TITLE
Adjust version of dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,8 +2,12 @@ project('webfuse', 'c', 'cpp', version: '0.6.0', license: 'LGPL-3.0+')
 
 without_tests = get_option('without_tests')
 
-libwebsockets_dep = dependency('libwebsockets', version: '>=4.0.0')
-libfuse_dep = dependency('fuse3', version: '>=3.8.0')
+libwebsockets_dep = dependency('libwebsockets', version: '>=4.0.0', required: false)
+if not libwebsockets_dep.found()
+  libwebsockets_dep = declare_dependency(link_with: 'websockets')
+endif
+
+libfuse_dep = dependency('fuse3', version: '>=3.1.0')
 
 pkg_config = import('pkgconfig')
 

--- a/meson.build
+++ b/meson.build
@@ -3,18 +3,8 @@ project('webfuse', 'c', 'cpp', version: '0.6.0', license: 'LGPL-3.0+')
 without_tests = get_option('without_tests')
 
 libwebsockets_dep = dependency('libwebsockets', version: '>=4.0.0', required: false)
-if not libwebsockets_dep.found()
-  libwebsockets_dep = declare_dependency(link_with: 'websockets')
-endif
 
-libfuse_dep = dependency('fuse3', version: '>=3.8.0', required: false)
-if not libfuse_dep.found()
-  thread_dep = dependency('threads')
-  libfuse_dep = declare_dependency(
-    link_with: ['fuse3'],
-    include_directories: ['fuse3'],
-    dependencies: thread_dep)
-endif
+libfuse_dep = dependency('fuse3', version: '>=3.1.0', required: false)
 
 pkg_config = import('pkgconfig')
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,14 @@ if not libwebsockets_dep.found()
   libwebsockets_dep = declare_dependency(link_with: 'websockets')
 endif
 
-libfuse_dep = dependency('fuse3', version: '>=3.1.0')
+libfuse_dep = dependency('fuse3', version: '>=3.8.0', required: false)
+if (no libfuse_dep.found()
+  thread_dep = dependency('threads')
+  libfuse_dep = declare_dependency(
+    link_with: ['fuse3'],
+    include_directories: ['fuse3'],
+    dependencies: thread_dep)
+endif
 
 pkg_config = import('pkgconfig')
 

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ if not libwebsockets_dep.found()
 endif
 
 libfuse_dep = dependency('fuse3', version: '>=3.8.0', required: false)
-if (no libfuse_dep.found()
+if not libfuse_dep.found()
   thread_dep = dependency('threads')
   libfuse_dep = declare_dependency(
     link_with: ['fuse3'],

--- a/meson.build
+++ b/meson.build
@@ -2,9 +2,8 @@ project('webfuse', 'c', 'cpp', version: '0.6.0', license: 'LGPL-3.0+')
 
 without_tests = get_option('without_tests')
 
-libwebsockets_dep = dependency('libwebsockets', version: '>=4.0.0', required: false)
-
-libfuse_dep = dependency('fuse3', version: '>=3.1.0', required: false)
+libwebsockets_dep = dependency('libwebsockets', version: '>=4.0.0')
+libfuse_dep = dependency('fuse3', version: '>=3.1.0')
 
 pkg_config = import('pkgconfig')
 


### PR DESCRIPTION
Reduce versions of dependencies to required versions, since we can not expect our users to use bleeding edge versions.