### PR TITLE
build and develop using docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "webfuse",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "..",
+        "target": "devcontainer"
+    },
+    "remoteUser": "user",
+    "mounts": [{
+        "source": "${localEnv:HOME}/.ssh",
+        "target": "/home/user/.ssh",
+        "type": "bind"
+    }],
+    
+    "customizations": {
+        "vscode": {
+            "extensions": [],
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash"
+            }
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
+/out/
 /.vscode/
 *.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:22.04 as builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y --no-install-recommends \
+    locales \
+    ca-certificates \
+    git \
+    build-essential \
+    pkg-config \
+    cmake \
+    libfuse3-dev \
+    libwebsockets-dev \
+    libgtest-dev \
+    libgmock-dev \
+    clang-tidy \
+    valgrind
+
+FROM builder as devcontainer
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME
+RUN useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+FROM builder as buildrun
+
+COPY . /src/webfuse
+# workaround:
+#   remote build directory, since --exclude is not available yet
+#   .dockerignore is not suitable since we want build directory be present in DevContainer
+RUN rm -rf /src/webfuse/build
+
+WORKDIR /src/webfuse
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITHOUT_TEST=ON -DWITHOUT_CLANG_TIDY=ON
+RUN cmake --build build
+RUN DESTDIR=out cmake --install build
+
+FROM scratch as build
+
+COPY --from=buildrun /src/webfuse/out /

--- a/doc/build.md
+++ b/doc/build.md
@@ -1,6 +1,18 @@
 # webfuse build instructions
 
-## Build
+## Build using Docker bake
+
+Use Docker bake to build without installing dependencies (aside of docker).
+
+```
+docker buildx bake
+```
+
+Find the build results in the `out` directory.
+
+## Build using CMake
+
+Please install the dependencies listed below before building using CMake.
 
 ````
 cmake -B build

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,10 @@
+group "default" {
+  targets = ["build"]
+}
+
+target "build" {
+    dockerfile = "Dockerfile"
+    context = "."
+    targets = ["build"]
+    output = ["out"]
+}

--- a/src/webfuse/fuse.cpp
+++ b/src/webfuse/fuse.cpp
@@ -186,11 +186,11 @@ static int fs_readdir(char const * path, void * buffer,
     auto const result = fs->readdir(path, names);
     if (0 == result)
     {
-        filler(buffer, ".", nullptr, 0, static_cast<fuse_fill_dir_flags>(0));
-        filler(buffer, "..", nullptr, 0, static_cast<fuse_fill_dir_flags>(0));
+        filler(buffer, ".", nullptr, 0, static_cast<fuse_fill_dir_flags>(0));  // NOLINT
+        filler(buffer, "..", nullptr, 0, static_cast<fuse_fill_dir_flags>(0)); // NOLINT
         for (auto const & name: names)
         {
-            filler(buffer, name.c_str(), nullptr, 0, static_cast<fuse_fill_dir_flags>(0));
+            filler(buffer, name.c_str(), nullptr, 0, static_cast<fuse_fill_dir_flags>(0)); // NOLINT
         }
     }
 


### PR DESCRIPTION
- add DevContainer note that integration tests will not run in devcontainer
- allow to build using docker buildx bake